### PR TITLE
Corrects rbenv installation

### DIFF
--- a/INSTALLFEST.md
+++ b/INSTALLFEST.md
@@ -583,12 +583,7 @@ sudo apt-get install libffi-dev
 1.  Next, we will install a default gem, `bundler`.
     ```bash
     # OSX and LINUX
-    touch ~/.rbenv/default-gems
-    ```
-    then:
-    ```bash
-    # OSX and LINUX
-    echo bundler < ~/.rbenv/default-gems
+    echo bundler > ~/.rbenv/default-gems
     ```
 
 1.  Install version 2.3.1 of Ruby and make it the system-wide default using the


### PR DESCRIPTION
Made a mistake in a previous commit that `>` the wrong way and
created a file unnecessarily. Fixes #72.